### PR TITLE
quick fix in destination value of player-cli

### DIFF
--- a/bin/handlerFunctions.js
+++ b/bin/handlerFunctions.js
@@ -858,7 +858,7 @@ async function push(argv){
         // check if file or directory
         const isFile = await checkDir(path);
 
-        const destination = argv.location.length ? argv.location : 'sd';
+        const destination = argv.location.length ? argv.location : '';
 
         if (isFile) {
             await pushFile(absPath, destination, playerData, argv.rawdata, argv.verbose);


### PR DESCRIPTION
This is a quick fix of a bug that snuck in recently. The `destination` positional in put file command refers to the directory to upload the file to, relative to the root of the storage. The storage type, stored in players.json, is prepended to the `destination` path given as a positional. So, because of this, the default for `destination` should be a blank string, not 'sd'. 

Impact of the bug was that every file pushed was being added to an `sd` directory on the SD card. 

This fix will restore the putfile command to its default behavior 