### PR TITLE
Pe 351/cec

### DIFF
--- a/bin/handlerFunctions.js
+++ b/bin/handlerFunctions.js
@@ -1284,6 +1284,38 @@ async function screenshot(argv) {
     }
 }
 
+async function sendCec(argv) {
+    // get player data from argv
+    let playerData;
+    try {
+        playerData = await pullData(argv);
+        // playerData[0] = playerUser, [1] = playerIP, [2] = playerPW
+    } catch (err) {
+        errorHandler(err);
+        return;
+    }
+    logIfOption('Sending CEC command to ' + argv.playerName, argv.verbose);
+    logIfOption('      IP address: ' + playerData[1] + ', username: ' + playerData[0] + ', password: ' + playerData[2], argv.verbose);
+    let requestOptions = {
+        method: 'POST',
+        url: 'http://' + playerData[1] + '/api/v1/sendCecX',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({hexCommand: argv.command})
+    };
+    logIfOption('Sending ' + requestOptions.method + ' request to ' + requestOptions.url, argv.verbose);
+    try {
+        let response = await requestFetch(requestOptions, playerData[0], playerData[2]);
+        logIfOption('Response received! => ', argv.verbose);
+        if (!argv.rawdata) {
+            console.log('CEC command sent: ' + response.data.result);
+        } else if (argv.rawdata) {
+            console.log(response.data.result);
+        }
+    } catch (err) {
+        errorHandler(err);
+    }
+}
+
 // General functions
 // confirm dangerous command
 function confirmDangerousCommand(prompt, callback) {
@@ -1683,5 +1715,6 @@ module.exports = {
     screenshot,
     generatePlayersJson,
     checkConfigExists,
-    helpChecker
+    helpChecker,
+    sendCec
 };

--- a/bin/handlerFunctions.js
+++ b/bin/handlerFunctions.js
@@ -1307,7 +1307,7 @@ async function sendCec(argv) {
         let response = await requestFetch(requestOptions, playerData[0], playerData[2]);
         logIfOption('Response received! => ', argv.verbose);
         if (!argv.rawdata) {
-            console.log('CEC command sent: ' + response.data.result);
+            console.log('CEC command sent: ' + response.data.result.success);
         } else if (argv.rawdata) {
             console.log(response.data.result);
         }

--- a/bin/index.js
+++ b/bin/index.js
@@ -85,7 +85,7 @@ yargs.command('getpowersave <playerName> [connector] [device]', 'Get the video c
 yargs.command('facreset <playerName>', 'Factory reset player', (yargs) => {positionals.facResetPositional(yargs)}, (argv) => {handlers.factoryReset(argv)});
 
 // Send CEC command
-yargs.command('sendcec <playerName> <command>', 'Send CEC command', (yargs) => {positionals.sendCecPositional(yargs)}, (argv) => {handlers.sendCec(argv)});
+yargs.command('sendcec <playerName> <command>', 'Send CEC command. Note that this command will only work on players running the newest version of supervisor', (yargs) => {positionals.sendCecPositional(yargs)}, (argv) => {handlers.sendCec(argv)});
 
 // define yargs options
 yargs.option('verbose', {

--- a/bin/index.js
+++ b/bin/index.js
@@ -84,6 +84,9 @@ yargs.command('getpowersave <playerName> [connector] [device]', 'Get the video c
 // Factory reset
 yargs.command('facreset <playerName>', 'Factory reset player', (yargs) => {positionals.facResetPositional(yargs)}, (argv) => {handlers.factoryReset(argv)});
 
+// Send CEC command
+yargs.command('sendcec <playerName> <command>', 'Send CEC command', (yargs) => {positionals.sendCecPositional(yargs)}, (argv) => {handlers.sendCec(argv)});
+
 // define yargs options
 yargs.option('verbose', {
   alias: 'v',

--- a/bin/positionalFunctions.js
+++ b/bin/positionalFunctions.js
@@ -296,6 +296,19 @@ function facResetPositional(yargs) {
     }); 
 }
 
+function sendCecPositional(yargs) {
+    yargs.positional('playerName', {
+        type: 'string',
+        default: 'player1',
+        describe: 'player name'
+    });
+    yargs.positional('command', {
+        type: 'string',
+        default: '',
+        describe: 'CEC command, direct passthrough'
+    });
+}
+
 module.exports = {
     getDiPositional,
     addPlayerPositional,
@@ -318,5 +331,6 @@ module.exports = {
     setRegPositional,
     setPowerSavePositional,
     getPowerSavePositional,
-    facResetPositional
+    facResetPositional,
+    sendCecPositional
 }


### PR DESCRIPTION
Added `sendcec` command that hits the new sendCecX endpoint. 

Work for https://brightsign.atlassian.net/browse/PE-351

Note - new command will only work on players with the new version of supervisor. 